### PR TITLE
Integrate memory into proxy requests/responses

### DIFF
--- a/services/api/app/completions/multiturn.py
+++ b/services/api/app/completions/multiturn.py
@@ -39,7 +39,7 @@ logger = get_logger(f"api.{__name__}")
 import uuid
 import httpx
 from datetime import datetime
-from transformers import AutoTokenizer
+import tiktoken
 
 from fastapi import APIRouter, HTTPException, status, Request
 from fastapi.responses import RedirectResponse
@@ -236,12 +236,8 @@ async def chat_completions(data: ChatCompletionRequest):
     prompt_text = " ".join(msg.content for msg in data.messages if msg.role in ["user", "assistant"])
 
     try:
-        # we're hardcoding this because... there's no real good way to get around this.
-        # the model name doesn't always easily translate to a tokenizer name.
-        # but we're using this model for chromadb embedding, so it makes sense to use it here.
-        # this is a bit of a hack, but it works for now.
-        tokenizer = AutoTokenizer.from_pretrained("intfloat/e5-small-v2")
-        tokens = tokenizer.encode(prompt_text)
+        enc = tiktoken.get_encoding("gpt2")
+        tokens = enc.encode(prompt_text)
 
     except Exception as err:
         logger.warning(f"Error retrieving encoding for model '{data.model}': {err}.")

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -4,7 +4,7 @@ graypy
 httpx
 requests
 python-dateutil
-transformers
+tiktoken
 opentelemetry-sdk
 opentelemetry-exporter-otlp
 opentelemetry-instrumentation-fastapi

--- a/services/intents/app/memory.py
+++ b/services/intents/app/memory.py
@@ -99,7 +99,7 @@ async def process_memory(message: ProxyMessage, component: str) -> ProxyMessage:
                     json_response = response.json()
                     mode = json_response.get("message", None)
 
-                entry = MemoryEntry(memory=clean_text, component=component, mode=mode)
+                entry = MemoryEntry(memory=clean_text, component=component, mode=mode, embedding=[])
                 async with httpx.AsyncClient(timeout=60) as client:
                     response = await client.request(
                         method="DELETE",

--- a/services/proxy/app/api/multiturn.py
+++ b/services/proxy/app/api/multiturn.py
@@ -145,7 +145,7 @@ async def from_api_multiturn(request: ProxyMultiTurnRequest) -> ProxyResponse:
         ),
         user_id="randi",
         context="\n".join(f"{m.role}: {m.content}" for m in request.messages),
-        memories=[]
+        memories=request.memories
     )
 
     # Check if the model supports instruct formatting.
@@ -173,7 +173,7 @@ async def from_api_multiturn(request: ProxyMultiTurnRequest) -> ProxyResponse:
         "raw": True
     }
 
-    logger.debug(f"Request from Ollama API:\n{json.dumps(payload, indent=4, ensure_ascii=False)}")
+    logger.debug(f"Request to Ollama API:\n{json.dumps(payload, indent=4, ensure_ascii=False)}")
 
     # Send the POST request using an async HTTP client
     async with httpx.AsyncClient(timeout=60) as client:

--- a/services/proxy/app/prompts/guest/generate.py
+++ b/services/proxy/app/prompts/guest/generate.py
@@ -14,6 +14,7 @@ Dependencies:
 """
 
 from shared.models.proxy import ProxyRequest
+from app.util import create_memory_str
 import re
 
 
@@ -27,6 +28,7 @@ def build_prompt(request: ProxyRequest) -> str:
     Returns:
         str: A formatted prompt string with conversation context and incoming message.
     """
+    joined_memories = create_memory_str(request.memories or [])
     decoded_context = request.context.encode('utf-8').decode('unicode_escape')
     context = re.sub(r'^"|"$', '', decoded_context)
     prompt = f"""You are responding to a message over {request.message.platform} from a user that is not Randi.

--- a/services/proxy/app/util.py
+++ b/services/proxy/app/util.py
@@ -1,20 +1,14 @@
 """
-This module provides utility functions for interacting with an Ollama language model 
-and processing user messages. It includes functions to send prompts to the LLM and
-determine if a model follows an instruct-style format.
+This module provides utility functions for interacting with a language model service 
+and processing memory entries. It includes functions to send prompts to the language 
+model, check if a model uses an instruct format, and create a string representation 
+of memory entries.
 Functions:
     - send_prompt_to_llm(prompt: str) -> dict:
-        Sends a prompt to the Ollama language model and retrieves its response.
+        Sends a prompt to the language model and retrieves its response.
     - is_instruct_model(model_name: str) -> bool:
-        Checks if a given model uses an instruct-style format by querying the 
-        /api/show endpoint.
-Constants:
-    - llm_model_name: The name of the default language model (retrieved from the 
-      environment variable 'LLM_MODEL_NAME', defaults to 'nemo').
-    - ollama_server_host: The host address of the Ollama server (retrieved from 
-      the environment variable 'OLLAMA_SERVER_HOST', defaults to 'localhost').
-    - ollama_server_port: The port number of the Ollama server (retrieved from 
-      the environment variable 'OLLAMA_SERVER_PORT', defaults to '11434').
+        Checks if a given model uses an instruct-style format by querying the service.
+    - create_memory_str(memories: List[MemoryEntryFull]) -> str:
 """
 
 import app.config
@@ -23,6 +17,8 @@ from shared.log_config import get_logger
 logger = get_logger(f"proxy.{__name__}")
 
 import httpx
+from typing import List
+from shared.models.chromadb import MemoryEntryFull
 
 async def send_prompt_to_llm(prompt: str) -> dict:
     """
@@ -99,3 +95,16 @@ async def is_instruct_model(model_name: str) -> bool:
         except Exception as exc:
             logger.warning(f"Failed to detect instruct format for model {model_name}: {exc}")
             return False
+
+
+def create_memory_str(memories: List[MemoryEntryFull]) -> str:
+    """
+    Converts a list of memory entries into a single string representation.
+    
+    Args:
+        memories (List[MemoryEntryFull]): A list of memory entries to be converted.
+    
+    Returns:
+        str: A single string with memory entries joined by newlines, in reverse order.
+    """
+    return "\n".join([f" - {m.memory}" for m in reversed(memories)])

--- a/shared/models/chromadb.py
+++ b/shared/models/chromadb.py
@@ -83,7 +83,7 @@ class MemoryMetadata(BaseModel):
         component (str): The component that created the memory.
         mode (str): The mode of the memory, defaulting to 'default' with options like 'nsfw'.
     """
-    timestamp: str                      = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z", description="Timestamp when the memory was created")  
+    timestamp: str                      = Field(default_factory=lambda: datetime.now().isoformat() + "Z", description="Timestamp when the memory was created")  
     priority: float                     = Field(..., ge=0, le=1, description="0=lowest, 1=highest")
     component: str                      = Field(..., description="Component that created the memory")
     mode: str                           = Field("default", description="Mode of the memory (e.g., 'nsfw', 'default')")

--- a/shared/models/proxy.py
+++ b/shared/models/proxy.py
@@ -16,7 +16,7 @@ Usage:
 
 from typing import List, Optional, Dict, Any, Literal
 from pydantic import BaseModel, Field
-
+from shared.models.chromadb import MemoryEntryFull
 
 class IncomingMessage(BaseModel):
     """
@@ -62,13 +62,13 @@ class ProxyRequest(BaseModel):
         user_id (str): The unique identifier of the user making the request.
         context (str): The context of the proxy request.
         mode (Optional[str], optional): An optional mode specification for the request. Defaults to None.
-        memories (Optional[List[str]], optional): An optional list of memory references. Defaults to None.
+        memories (Optional[List[MemoryEntryFull]], optional): A list of memory entries associated with the request. Defaults to None.
     """
-    message: IncomingMessage
-    user_id: str
-    context: str
-    mode: Optional[str] = None
-    memories: Optional[List[str]] = None
+    message: IncomingMessage                        = Field(..., description="The incoming message associated with the proxy request.")
+    user_id: str                                    = Field(..., description="The unique identifier of the user making the request.")
+    context: str                                    = Field(..., description="The context of the proxy request.")
+    mode: Optional[str]                             = Field(None, description="An optional mode specification for the request.")
+    memories: Optional[List[MemoryEntryFull]]       = Field(None, description="An optional list of memory references.")
 
 
 # reworked models go down here
@@ -121,11 +121,13 @@ class ProxyMultiTurnRequest(BaseModel):
         messages (List[ProxyMessage]): A list of messages representing the conversation history.
         temperature (float): Controls the randomness of the model's output. Defaults to 0.7.
         max_tokens (int): The maximum number of tokens to generate in the response. Defaults to 256.
+        memories (Optional[List[MemoryEntryFull]]): A list of memory entries associated with the conversation.
     """
-    model: Optional[str]                = Field('nemo', description="The model to be used for generating the response.")
-    messages: List[ProxyMessage]        = Field(..., description="List of messages for multi-turn conversation.")
-    temperature: Optional[float]        = Field(0.7, description="The temperature setting for randomness in the model's output.")
-    max_tokens: Optional[int]           = Field(256, description="The maximum number of tokens to generate in the response.")
+    model: Optional[str]                        = Field('nemo', description="The model to be used for generating the response.")
+    messages: List[ProxyMessage]                = Field(..., description="List of messages for multi-turn conversation.")
+    temperature: Optional[float]                = Field(0.7, description="The temperature setting for randomness in the model's output.")
+    max_tokens: Optional[int]                   = Field(256, description="The maximum number of tokens to generate in the response.")
+    memories: Optional[List[MemoryEntryFull]]   = Field(None, description="List of memory entries associated with the conversation.")
 
     class Config:
         json_schema_extra = {
@@ -142,7 +144,15 @@ class ProxyMultiTurnRequest(BaseModel):
                     }
                 ],
                 "temperature": 0.7,
-                "max_tokens": 256
+                "max_tokens": 256,
+                "memories": [
+                    {
+                        "memory": "Reminder to take meds",
+                        "component": "health",
+                        "priority": 1.0,
+                        "mode": "default"
+                    }
+                ]
             }
         }
 


### PR DESCRIPTION
- Update `ProxyRequest` and `ProxyMultiTurnRequest` models in `shared/models/proxy.py` to include an optional `memories` field, allowing a list of `MemoryEntryFull` objects to be passed.
- Modify `outgoing_multiturn_message` in `services/brain/app/message/multiturn.py` to fetch memories based on the current mode and include them in the proxy request. Also, strip `<details>` tags from messages to prevent model bias.
- Update `from_api_multiturn` in `services/proxy/app/api/multiturn.py` to pass memories from the request to the Ollama API.
- Add `create_memory_str` function in `services/proxy/app/util.py` to format memory entries into a string for the prompt.
- Modify `build_prompt` in `services/proxy/app/prompts/guest/generate.py` to include memory context in the prompt.
- Replace `transformers` dependency with `tiktoken` in `services/api/requirements.txt` and update `chat_completions` in `services/api/app/completions/multiturn.py` to use `tiktoken` for token encoding.
- Add `embedding` field to `MemoryEntry` in `services/intents/app/memory.py`
- Update timestamp generation in `MemoryMetadata` in `shared/models/chromadb.py` to use `datetime.now()` for local time.
- Create `services/api/app/util.py`

Refs re-implement memories #30 and update intents for memory functions #34 and #37